### PR TITLE
Reply to wait commands when done

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,8 @@ It does the following:
            simulation time too)
 
 * It handles the wait requests from the EDTT driver by letting the simulation
-  advance by that amount of time
+  advance by that amount of time and replying with a dummy byte (with a value of 0)
+  when the wait has completed
 
 Effectively it either blocks the simulator or the EDTTool so that only one
 executes at a time, locksteping them to ensure that simulations are fully

--- a/src/main.c
+++ b/src/main.c
@@ -82,7 +82,7 @@ int receive_and_process_command_from_edtt(){
    *    1 byte : reception done (0) or timeout (1)
    *    8 bytes: timestamp when the reception or timeout actually happened
    *    0/N bytes: (0 bytes if timeout, N bytes as requested otherwise)
-   *  to a WAIT: nothing
+   *  to a WAIT: 1 byte (0) when wait is done
    *  to a DISCONNECT: nothing
    */
 #define DISCONNECT 0
@@ -117,6 +117,8 @@ int receive_and_process_command_from_edtt(){
       } else {
         bs_trace_warning_manual_time_line(Now,"Wait into the past (%"PRItime") ignored\n", wait_s.end);
       }
+      uint8_t reply = 0;
+      edtt_write(&reply, 1);
       break;
     }
     case SEND:


### PR DESCRIPTION
EDTT needs to know when a wait is done to work correctly, so wait commands are now replied to after the wait completes

Signed-off-by: Troels Nilsson <trnn@demant.com>