### PR TITLE
Add support for new RCV_WAIT_NOTIFY command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,10 @@ It does the following:
          * The time in which the read has been actually finalized (or timeout
            occurred) is sent back to the EDTT (the EDTT driver knows the
            simulation time too)
+    * Receive with wait notify requests:
+
+         * Same as normal receive requests, except that whenever the bridge waits it
+           will first notify the EDTT bridge via a wait notification message
 
 * It handles the wait requests from the EDTT driver by letting the simulation
   advance by that amount of time and replying with a dummy byte (with a value of 0)


### PR DESCRIPTION
Adds a new RCV_WAIT_NOTIFY command and WAIT_NOTIFICATION message

The RCV_WAIT_NOTIFY command is the same as RCV, except that
a WAIT_NOTIFICATION message is sent when the bridge waits in a
RCV_WAIT_NOTIFY command; This allows the EDTT to have another BSim device
attached for injecting packets while still allowing the simulation time
to advance for the bridge

Signed-off-by: Troels Nilsson <trnn@demant.com>