### PR TITLE
Fix regression due to WAIT response

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,8 +25,8 @@ It does the following:
            will first notify the EDTT bridge via a wait notification message
 
 * It handles the wait requests from the EDTT driver by letting the simulation
-  advance by that amount of time and replying with a dummy byte (with a value of 0)
-  when the wait has completed
+  advance by that amount of time and, if the wait requested a response, replying
+  with a dummy byte (with a value of 0) when the wait has completed
 
 Effectively it either blocks the simulator or the EDTTool so that only one
 executes at a time, locksteping them to ensure that simulations are fully

--- a/src/main.c
+++ b/src/main.c
@@ -107,6 +107,7 @@ int receive_and_process_command_from_edtt(){
 #define RCV_WAIT_NOTIFY 4
 
 #define WAIT_NOTIFICATION 0xF0
+#define UNKNOWN_COMMAND 0xFF
 
   uint8_t command = DISCONNECT;
 
@@ -205,8 +206,14 @@ int receive_and_process_command_from_edtt(){
       break;
     }
     default:
-      bs_trace_error_line("Can't understand command %u\n", command);
+    {
+      uint8_t reply = UNKNOWN_COMMAND;
+      edtt_write(&reply, sizeof(reply)); //Before dying, let's tell the EDTT of the incompatibility
+      bs_trace_error_line("Can't understand command %u;"
+                          "Most likely the EDTT version you are using requires a newer bridge\n",
+                          command);
       break;
+    }
   }
 
   return 0;


### PR DESCRIPTION
As discussed in discord:

To retain backwards compatibility with older EDTT versions
(and therefore its users like Zephyr)
revert the functional change in
https://github.com/BabbleSim/ext_device_EDTT_bridge/commit/0948b43e890292f0d4e8f50590fc57bdb51c114b
so that a WAIT command does not reply anything.
Instead, add a new WAIT_WREPLY command,
which does provide that reply to the EDTT,
to enable the low level device functionality
in the EDTT.

Note that this breaks compatibility with EDTT versions
between EDTT versionns
18744c937131104797ea0abf0dcfc84855a12311 (2022/11/24)
and the corresponding update (expeted 2023/01/17)
And recovers backwards compatibility prior to
18744c937131104797ea0abf0dcfc84855a12311

Reply with UNKNOWN_COMMAND when receiving a not known command
from the EDTT python code
And provide a more descriptive error message